### PR TITLE
Added a new parameter 'sort' that can contain either 'layer' or 'name' to customize sorting

### DIFF
--- a/example/app/app.component.html
+++ b/example/app/app.component.html
@@ -5,7 +5,7 @@
     <p>Antwerp street names:</p>
     <aui-location-picker
         placeholder="kies een straat"
-        types="street"
+        sort="layer"
         [(value)]="picker1"
         url="http://localhost:9999/api/locations">
     </aui-location-picker>

--- a/src/location-picker/location-picker.component.ts
+++ b/src/location-picker/location-picker.component.ts
@@ -46,6 +46,8 @@ export class LocationPickerComponent
     @Input() public noDataMessage = 'Geen resultaat gevonden';
     /** the type of values to search for, comma-separated list of "street", "number" or "poi" */
     @Input() public types = 'street,number,poi';
+    /* the manner in which the user would like to sort results, by default sorting by name happens */
+    @Input() public sort = 'name';
     /** the value that is displayed */
     @Input() public value: LocationPickerValue;
     /** how long to buffer keystrokes before requesting search results */
@@ -91,7 +93,7 @@ export class LocationPickerComponent
             .pipe(
               debounceTime(this.bufferInputMs),
               mergeMap((search) =>
-                this.locationService.getLocationsByQuery(this.url, String(search), this.types)
+                this.locationService.getLocationsByQuery(this.url, String(search), this.types, this.sort)
               )
             )
             .subscribe((results) => {

--- a/src/location-picker/location-picker.service.ts
+++ b/src/location-picker/location-picker.service.ts
@@ -19,13 +19,16 @@ export class LocationPickerService {
         /** The string to search for */
         search: string,
         /** The types of locations to search for (comma-separated) */
-        types: string
+        types: string,
+        /** The way to sort (name by default) */
+        sort: string
     ): Observable<LocationPickerValue[]> {
         if (typeof dataSource === 'string') {
             const uri = dataSource +
                 ((dataSource.indexOf('?') < 0) ? '?' : '&') +
                 'search=' + search +
-                (types ? '&types=' + types : '');
+                (types ? '&types=' + types : '') +
+                (sort ? '&sort=' + sort : '');
             return this.http.get<LocationPickerValue[]>(uri);
         } else {
             // should never happen


### PR DESCRIPTION
It is now possible to use the 'sort' parameter to specify how you want to sort your results. Currently the service supports sorting by 'name' and 'layer'.

https://jira.antwerpen.be/browse/GIS-74