### PR TITLE
Added search value normalization

### DIFF
--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
@@ -353,6 +353,8 @@ export class NgxLocationPickerComponent implements OnInit, OnDestroy, ControlVal
         this.addMapMarker([coords.x, coords.y]);
       }
 
+      searchValue = this.locationPickerHelper.normalizeSearchValue(searchValue);
+
       this.locationServiceSubscription = this.locationPickerService.delegateSearch(
         searchValue,
         this.baseUrl,
@@ -596,8 +598,6 @@ export class NgxLocationPickerComponent implements OnInit, OnDestroy, ControlVal
     this.leafletMap.setView(coords, this.onSelectZoom);
 
     if (location) {
-      console.log(location);
-
       this.writeValue(location);
     }
   }

--- a/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
+++ b/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
@@ -64,6 +64,29 @@ export class NgxLocationPickerHelper {
   }
 
   /**
+   * Normalize search value
+   *
+   * @return string
+   */
+  normalizeSearchValue(value: string) {
+    if (!this.isCoordinate(value)) {
+      const hasBrackets = value.match(/\(.*?\)/);
+
+      if (hasBrackets && hasBrackets.length) {
+        return value.replace(` ${hasBrackets}`, '');
+      } else {
+        const hasComma = value.indexOf(',');
+
+        if (hasComma) {
+          return value.replace(value.substr(hasComma, value.length), '');
+        }
+      }
+    }
+
+    return value;
+  }
+
+  /**
    * Determines if the given query input resembles an address or not.
    *
    * @return boolean
@@ -111,8 +134,6 @@ export class NgxLocationPickerHelper {
       streetname: '',
       housenumber: ''
     };
-
-    query = query.split(',')[0];
 
     const addressParts: Array<string> = (query && query.trim().length > 0) ? query.split(' ') : null;
 


### PR DESCRIPTION
Search value will now be filtered. eg: (Antwerpen) and , 2000 Antwerpen will be stripped from search query to allow better switching between locations <=> addresses when using the input field.