### PR TITLE
locationModel type postCode: number is now postCodes: Array<number>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- LocationModel: renamed type postCode: number to postCodes: Array\<number>
 
 ## [4.4.0] - 2020-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- LocationModel: added postCode: number AND postCodes: Array<number>
 - LocationModel: renamed type postCode: number to postCodes: Array\<number>
 
 ## [4.4.0] - 2020-03-30

--- a/projects/ngx-location-picker/src/lib/types/location.model.ts
+++ b/projects/ngx-location-picker/src/lib/types/location.model.ts
@@ -6,7 +6,7 @@ export interface LocationModel {
     layer?: string;
     streetNameId?: number;
     streetName?: string;
-    postCode?: number;
+    postCodes?: Array<number>;
     antwerpDistrict?: string;
     municipality?: string;
     label?: string;

--- a/projects/ngx-location-picker/src/lib/types/location.model.ts
+++ b/projects/ngx-location-picker/src/lib/types/location.model.ts
@@ -7,6 +7,7 @@ export interface LocationModel {
     streetNameId?: number;
     streetName?: string;
     postCodes?: Array<number>;
+    postCode?: number;
     antwerpDistrict?: string;
     municipality?: string;
     label?: string;


### PR DESCRIPTION
This is a minor change. The field postCode is now postCodes with a type Array<number>. This should have no impact on existing projects as the postCode field was not populated until today, api was updated as well to return the postCodes for a given location.