### PR TITLE
Fix: What is here Pin is now set right and also the `luchtfoto` is now set to the newer version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file.
 "### Fixed" for any bug fixes.
 "### Security" in case of vulnerabilities.
 -->
+## [7.0.4]
+
+### Fixed
+
+- Fixed `what is here` icons & colors.
+
+### Changed
+
+- Changed `luchtfoto` to a newer version.
+
 ## [7.0.3]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 -->
 ## [7.0.4]
 
+### Added
+
+- Added `bufferSearch` parameter to the widget, it will be used for searches on addresses, locations and coordinates.
+
 ### Fixed
 
 - Fixed `what is here` icons & colors.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ selectedLocation: InitialLocationModel = {
     [sortBy]="sortBy"
     [onlyAntwerp]="onlyAntwerp"
     [countryCodes]="countryCodes"
+    [bufferSearch]="bufferSearch"
     [coordinateErrorNotification]="coordinateErrorNotification"
     [locateMeNotAllowedNotification]="locateMeNotAllowedNotification"
     [locateMeNotSupportedNotification]="locateMeNotSupportedNotification"
@@ -331,10 +332,12 @@ class ExampleComponent {
     @Input() onlyAntwerp = true;
     /* Search locations and addresses in provided country codes if 'onlyAntwerp' is false*/
     @Input() countryCodes = ['be','nl','lu'];
+    /* The buffer that will be used when searching for locations, in km. (by default no buffer is used)*/
+    @Input() bufferSearch?: number;
     /* Use geolocation when the component finished loading */
     @Input() locateUserOnInit = false;
     /* Set time to wait after user stops typing before triggering a search */
-    @Input() debounceTime = 200;
+    @Input() debounceTime = 400;
     /* whether or not to return a single cascading result */
     @Input() cascadingCoordinateReturnSingle = true;
     /* Limit total cascading result, useful when returnSingle is false */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@acpaas-ui-widgets/ngx-location-viewer": "^3.1.3",
         "@acpaas-ui/ngx-icon": "^6.0.9",
-        "@acpaas-ui/ngx-leaflet": "^6.0.9"
+        "@acpaas-ui/ngx-leaflet": "^6.0.10"
       },
       "devDependencies": {
         "@a-ui/core": "^6.6.0",
@@ -78,11 +78,11 @@
       }
     },
     "node_modules/@acpaas-ui/ngx-flyout": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-flyout/-/ngx-flyout-6.0.9.tgz",
-      "integrity": "sha512-TTs/r0SfjNTKHKh4cv0X4fPx0FcJEP59jfWm7kwLrQuXgBOQYGo6YuVVxp/hiwECKCfHaypKegjdQaDzy73MtA==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-flyout/-/ngx-flyout-6.0.10.tgz",
+      "integrity": "sha512-Ck/mGW0ZXsKVn1Zn3Ez5bTzZDNPK9ZsNKj56O9Datg5TNfzwFuEXmPb6asZfFoznZ7IGvGiPDtadBjlfobu8zg==",
       "dependencies": {
-        "@acpaas-ui/ngx-icon": "^6.0.9",
+        "@acpaas-ui/ngx-icon": "^6.0.10",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@acpaas-ui/ngx-icon": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-icon/-/ngx-icon-6.0.9.tgz",
-      "integrity": "sha512-KKjc4tPhLfmceXFogCbaK6Zgdx9HWGSIZ5H/nPRfv3vgztyuUrnanTsX7pdvSPPZzdB9DjwLvYZwlWz0sIO8WQ==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-icon/-/ngx-icon-6.0.10.tgz",
+      "integrity": "sha512-S7HuMfgibgknij6tJPhbFXDaUZzza8WAkJIvfC7PQgm2CkwLO9WtWURGf4ayXcgs+3/fTsoZwjCgcpvlcZ495g==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -104,12 +104,12 @@
       }
     },
     "node_modules/@acpaas-ui/ngx-leaflet": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-leaflet/-/ngx-leaflet-6.0.9.tgz",
-      "integrity": "sha512-J0pIS+65OnKOWRwTKa+85htk0dgKIDxVS0Ju7ll4awYVuHBGzjXhA1r9ih3NVT1D13pzZCVVQqaySqbVPBPjKg==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-leaflet/-/ngx-leaflet-6.0.10.tgz",
+      "integrity": "sha512-Qddm3teA85DjBP0TaGHdbZDVx/broMzm1LAU5KomDyliKRVagTbVYWbvxdoETbpj7uol1IR8brmm2rc1goi1mg==",
       "dependencies": {
-        "@acpaas-ui/ngx-flyout": "^6.0.9",
-        "@acpaas-ui/ngx-icon": "^6.0.9",
+        "@acpaas-ui/ngx-flyout": "^6.0.10",
+        "@acpaas-ui/ngx-icon": "^6.0.10",
         "esri-leaflet": "^3.0.2",
         "leaflet": "^1.3.1",
         "leaflet-draw": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@acpaas-ui-widgets/ngx-location-picker",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acpaas-ui-widgets/ngx-location-picker",
-      "version": "7.0.3",
+      "version": "7.0.4",
       "dependencies": {
         "@acpaas-ui-widgets/ngx-location-viewer": "^3.1.3",
-        "@acpaas-ui/ngx-icon": "^6.0.0",
-        "@acpaas-ui/ngx-leaflet": "^6.0.0"
+        "@acpaas-ui/ngx-icon": "^6.0.9",
+        "@acpaas-ui/ngx-leaflet": "^6.0.9"
       },
       "devDependencies": {
         "@a-ui/core": "^6.6.0",
@@ -78,11 +78,11 @@
       }
     },
     "node_modules/@acpaas-ui/ngx-flyout": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-flyout/-/ngx-flyout-6.0.7.tgz",
-      "integrity": "sha512-+/E2rg/repiUPq2zoT0T1ViQXQUK8Owzo602Qesc1zAeL4crRmJZqU/P5i6K8F4fvc5ZCi/Z8sINZNOUUlABVQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-flyout/-/ngx-flyout-6.0.9.tgz",
+      "integrity": "sha512-TTs/r0SfjNTKHKh4cv0X4fPx0FcJEP59jfWm7kwLrQuXgBOQYGo6YuVVxp/hiwECKCfHaypKegjdQaDzy73MtA==",
       "dependencies": {
-        "@acpaas-ui/ngx-icon": "^6.0.6",
+        "@acpaas-ui/ngx-icon": "^6.0.9",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
@@ -91,10 +91,10 @@
         "@angular/platform-browser": ">=15.2.0"
       }
     },
-    "node_modules/@acpaas-ui/ngx-flyout/node_modules/@acpaas-ui/ngx-icon": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-icon/-/ngx-icon-6.0.6.tgz",
-      "integrity": "sha512-+s69nz8XCs1WmBVY+UlksnkODotsvycLl1skH2FoTV4X6b5OhGunG/mJhkWE2XJfLKKp0vk8dytY2OiCOrLGIQ==",
+    "node_modules/@acpaas-ui/ngx-icon": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-icon/-/ngx-icon-6.0.9.tgz",
+      "integrity": "sha512-KKjc4tPhLfmceXFogCbaK6Zgdx9HWGSIZ5H/nPRfv3vgztyuUrnanTsX7pdvSPPZzdB9DjwLvYZwlWz0sIO8WQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -103,25 +103,13 @@
         "@angular/core": ">=15.2.0"
       }
     },
-    "node_modules/@acpaas-ui/ngx-icon": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-icon/-/ngx-icon-6.0.0.tgz",
-      "integrity": "sha512-M6AgY1b8SFjbSrrLgd6slGAzXliNleVvHhkTOULEDA2esjUZBs1nCNTftYOW1I06t0ISUUlbE45IVDo0kxsW/w==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "^15.2.0",
-        "@angular/core": "^15.2.0"
-      }
-    },
     "node_modules/@acpaas-ui/ngx-leaflet": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-leaflet/-/ngx-leaflet-6.0.0.tgz",
-      "integrity": "sha512-mcABl872PSBCDU+bFWX17YI6EGUT7MLBR4bdqnMma/HpP1Zr1sBAH7iaDa+cJ6Of9w5HxRe7gEJiRv3ER5TUaw==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@acpaas-ui/ngx-leaflet/-/ngx-leaflet-6.0.9.tgz",
+      "integrity": "sha512-J0pIS+65OnKOWRwTKa+85htk0dgKIDxVS0Ju7ll4awYVuHBGzjXhA1r9ih3NVT1D13pzZCVVQqaySqbVPBPjKg==",
       "dependencies": {
-        "@acpaas-ui/ngx-flyout": "^6.0.0",
-        "@acpaas-ui/ngx-icon": "^6.0.0",
+        "@acpaas-ui/ngx-flyout": "^6.0.9",
+        "@acpaas-ui/ngx-icon": "^6.0.9",
         "esri-leaflet": "^3.0.2",
         "leaflet": "^1.3.1",
         "leaflet-draw": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@acpaas-ui-widgets/ngx-location-viewer": "^3.1.3",
     "@acpaas-ui/ngx-icon": "^6.0.9",
-    "@acpaas-ui/ngx-leaflet": "^6.0.9"
+    "@acpaas-ui/ngx-leaflet": "^6.0.10"
   },
   "devDependencies": {
     "@a-ui/core": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@acpaas-ui-widgets/ngx-location-picker",
   "description": "Location Picker Smart Widget UI package (Angular)",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@acpaas-ui-widgets/ngx-location-viewer": "^3.1.3",
-    "@acpaas-ui/ngx-icon": "^6.0.0",
-    "@acpaas-ui/ngx-leaflet": "^6.0.0"
+    "@acpaas-ui/ngx-icon": "^6.0.9",
+    "@acpaas-ui/ngx-leaflet": "^6.0.9"
   },
   "devDependencies": {
     "@a-ui/core": "^6.6.0",

--- a/projects/example/src/app/app.component.html
+++ b/projects/example/src/app/app.component.html
@@ -8,9 +8,15 @@
   </div>
 
   <form (ngSubmit)="onSubmitNgModel()">
-    <aui-location-picker name="locationPickerModel" [baseUrl]="baseUrl + '/v1'" [(ngModel)]="selectedLocationModel"
-      [locationLayers]="['all']" [hasSidebar]="false" [tileLayer]="satelliteMapLayer"
-      [cascadingCoordinateReturnSingle]="false" [cascadingCoordinateRules]="cascadingRules"></aui-location-picker>
+    <aui-location-picker name="locationPickerModel"
+                         [baseUrl]="baseUrl + '/v1'"
+                         [(ngModel)]="selectedLocationModel"
+                         [locationLayers]="['all']"
+                         [hasSidebar]="false"
+                         [tileLayer]="satelliteMapLayer"
+                         [cascadingCoordinateReturnSingle]="false"
+                         [cascadingCoordinateRules]="cascadingRules"
+    ></aui-location-picker>
     <button type="submit" class="a-button u-margin-top">Log to browser console</button>
 
     <pre>{{ selectedLocationModel | json }}</pre>

--- a/projects/example/src/app/app.component.ts
+++ b/projects/example/src/app/app.component.ts
@@ -16,7 +16,7 @@ export class AppComponent implements OnInit {
   satelliteMapLayer: LeafletTileLayerModel = {
     layer: {
       name: 'Satellite View',
-      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'
+      url: 'https://geodata.antwerpen.be/arcgissql/rest/services/P_Publiek/Luchtfoto_actueel_wgs84/MapServer/tile/{z}/{y}/{x}',
     },
     buttonLabel: 'Luchtfoto'
   };

--- a/projects/ngx-location-picker/package.json
+++ b/projects/ngx-location-picker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@acpaas-ui-widgets/ngx-location-picker",
   "description": "Location Picker Smart Widget UI package (Angular)",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "license": "See license file",
   "repository": {
     "type": "git",

--- a/projects/ngx-location-picker/package.json
+++ b/projects/ngx-location-picker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@acpaas-ui-widgets/ngx-location-picker",
   "description": "Location Picker Smart Widget UI package (Angular)",
-  "version": "7.0.4",
+  "version": "7.0.3",
   "license": "See license file",
   "repository": {
     "type": "git",
@@ -10,7 +10,7 @@
   "peerDependencies": {
     "@acpaas-ui-widgets/ngx-location-viewer": "^3.1.3",
     "@acpaas-ui/ngx-icon": "^6.0.0",
-    "@acpaas-ui/ngx-leaflet": "^6.0.0",
+    "@acpaas-ui/ngx-leaflet": "^6.0.10",
     "@angular/common": "^15.2.9",
     "@angular/core": "^15.2.9"
   },

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.scss
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.scss
@@ -17,8 +17,8 @@
   .is-picking {
     .leaflet-grab,
     .leaflet-interactive {
-      cursor: url('data:image/svg+xml,<svg viewBox="-24 -10 30 30" xmlns="http://www.w3.org/2000/svg"><g stroke-linecap="round" stroke="%230057b7" fill="none" stroke-linejoin="round"><path d="M1 3.5a4 4 0 1 0 0 8 4 4 0 1 0 0-8Z"/><path d="M1 11.5l0 9"/></g></svg>')
-      15 12,
+      cursor: url('data:image/svg+xml,<svg viewBox="0 0 36 36" stroke-width="2" xmlns="http://www.w3.org/2000/svg"><g stroke-width="2" stroke-linecap="round" stroke="%230057b7" fill="none" stroke-linejoin="round"><path stroke-width="2" d="M12 3.5a4 4 0 1 0 0 8 4 4 0 1 0 0-8Z"/><path d="M12 11.5l0 9"/></g></svg>')
+      14 16,
         pointer;
     }
   }

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.scss
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.scss
@@ -15,10 +15,10 @@
   }
 
   .is-picking {
-
     .leaflet-grab,
     .leaflet-interactive {
-      cursor: url('data:image/svg+xml,<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke-linecap="round" stroke="%23000" fill="none" stroke-linejoin="round"><path d="M12 3.5a4 4 0 1 0 0 8 4 4 0 1 0 0-8Z"/><path d="M12 11.5l0 9"/></g></svg>') 18 36,
+      cursor: url('data:image/svg+xml,<svg viewBox="-24 -10 30 30" xmlns="http://www.w3.org/2000/svg"><g stroke-linecap="round" stroke="%230057b7" fill="none" stroke-linejoin="round"><path d="M1 3.5a4 4 0 1 0 0 8 4 4 0 1 0 0-8Z"/><path d="M1 11.5l0 9"/></g></svg>')
+      15 12,
         pointer;
     }
   }

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
@@ -139,8 +139,10 @@ export class NgxLocationPickerComponent
   @Input() sortBy = "";
   /* Search locations and addresses inside Antwerp otherwise will search in provided countries ==> countryCodes */
   @Input() onlyAntwerp = true;
-  /* Search locations and addresses in provided country codes if 'onlyAntwerp' is false*/
+  /* Search locations and addresses in provided country codes if 'onlyAntwerp' is false */
   @Input() countryCodes = ["be", "nl", "lu"];
+  /* The buffer that will be used when searching for locations, in km. (by default no buffer is used)*/
+  @Input() bufferSearch?: number;
   /* Use geolocation when the component finished loading */
   @Input() locateUserOnInit = false;
   /* Set time to wait after user stops typing before triggering a search */
@@ -585,6 +587,7 @@ export class NgxLocationPickerComponent
         searchStreetNameForAddress: this.searchStreetNameForAddress,
         onlyAntwerp: this.onlyAntwerp,
         countryCodes: this.countryCodes,
+        bufferSearch: this.bufferSearch,
       };
 
       this.locationServiceSubscription = this.locationPickerService
@@ -1059,8 +1062,8 @@ export class NgxLocationPickerComponent
     icon: string = "ai-pin-3",
     size: string = "1.5rem",
     position: { top: string; left: string } = {
-      top: "4px",
-      left: "4px",
+      top: "-0.75rem",
+      left: "-0.6rem",
     }
   ) {
     const markerStyle = `color: ${color}; font-size: ${size}; top: ${position.top}; left: ${position.left}`;
@@ -1071,8 +1074,8 @@ export class NgxLocationPickerComponent
 
   private createPinMarker(): string {
     return this.createMarker("var(--THEME1-600)", "ai-pin", "2.5rem", {
-      top: "0",
-      left: "0",
+      top: "-1.75rem",
+      left: "-0.75rem",
     });
   }
 

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
@@ -1055,7 +1055,7 @@ export class NgxLocationPickerComponent
    * Defines the custom marker markup.
    */
   private createMarker(
-    color: string = "var(--TEXT-COLOR)",
+    color: string = "var(--THEME1-600)",
     icon: string = "ai-pin-3",
     size: string = "1.5rem",
     position: { top: string; left: string } = {
@@ -1071,8 +1071,8 @@ export class NgxLocationPickerComponent
 
   private createPinMarker(): string {
     return this.createMarker("var(--THEME1-600)", "ai-pin", "2.5rem", {
-      top: "-8px",
-      left: "-4px",
+      top: "0",
+      left: "0",
     });
   }
 

--- a/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
+++ b/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
@@ -195,7 +195,8 @@ export class NgxLocationPickerHelper {
     query: string,
     selectedLocation: LocationModel | AddressModel | CoordinateModel,
     onlyAntwerp: boolean,
-    countryCodes: string[]
+    countryCodes: string[],
+    buffer?: number
   ): AddressQueryModel {
     const streetAndNumber: AddressQueryModel = {
       streetname: "",
@@ -203,6 +204,7 @@ export class NgxLocationPickerHelper {
       housenumber: "",
       onlyAntwerp: onlyAntwerp,
       countries: countryCodes,
+      buffer: buffer,
     };
 
     const addressParts: Array<string> =

--- a/projects/ngx-location-picker/src/lib/services/ngx-location-picker.service.ts
+++ b/projects/ngx-location-picker/src/lib/services/ngx-location-picker.service.ts
@@ -57,7 +57,8 @@ export class NgxLocationPickerService {
         ycoord: coordinate.y,
         returnsingle: delegateSearch.cascadingCoordinateReturnSingle,
         totalresults: delegateSearch.cascadingCoordinateLimit,
-        cascadingRules: delegateSearch.cascadingCoordinateRules
+        cascadingRules: delegateSearch.cascadingCoordinateRules,
+        buffer: delegateSearch.bufferSearch,
       };
 
       return this.searchLocationsByCoordinates(requestQuery);
@@ -66,7 +67,8 @@ export class NgxLocationPickerService {
         delegateSearch.search,
         delegateSearch.selectedLocation,
         delegateSearch.onlyAntwerp,
-        delegateSearch.countryCodes
+        delegateSearch.countryCodes,
+        delegateSearch.bufferSearch
       );
       if (delegateSearch.searchStreetNameForAddress) {
         const locationQuery: LocationQueryModel = {
@@ -76,10 +78,11 @@ export class NgxLocationPickerService {
           prioritizelayer: delegateSearch.prioritizelayer,
           sort: delegateSearch.sort,
           onlyAntwerp: delegateSearch.onlyAntwerp,
-          countries: delegateSearch.countryCodes
+          countries: delegateSearch.countryCodes,
+          buffer: delegateSearch.bufferSearch,
         };
-  
-        return this.searchLocations(locationQuery);    
+
+        return this.searchLocations(locationQuery);
       } else {
         return this.searchAddresses(addressQuery);
       }
@@ -91,7 +94,8 @@ export class NgxLocationPickerService {
         prioritizelayer: delegateSearch.prioritizelayer,
         sort: delegateSearch.sort,
         onlyAntwerp: delegateSearch.onlyAntwerp,
-        countries: delegateSearch.countryCodes
+        countries: delegateSearch.countryCodes,
+        buffer: delegateSearch.bufferSearch,
       };
 
       return this.searchLocations(locationQuery);

--- a/projects/ngx-location-picker/src/lib/types/address-query.model.ts
+++ b/projects/ngx-location-picker/src/lib/types/address-query.model.ts
@@ -4,5 +4,5 @@ export interface AddressQueryModel {
   housenumber: string;
   onlyAntwerp: boolean;
   countries: string[];
-  buffer?:number;
+  buffer? :number;
 }

--- a/projects/ngx-location-picker/src/lib/types/address-query.model.ts
+++ b/projects/ngx-location-picker/src/lib/types/address-query.model.ts
@@ -4,5 +4,5 @@ export interface AddressQueryModel {
   housenumber: string;
   onlyAntwerp: boolean;
   countries: string[];
-  buffer? :number;
+  buffer?: number;
 }

--- a/projects/ngx-location-picker/src/lib/types/address-query.model.ts
+++ b/projects/ngx-location-picker/src/lib/types/address-query.model.ts
@@ -4,4 +4,5 @@ export interface AddressQueryModel {
   housenumber: string;
   onlyAntwerp: boolean;
   countries: string[];
+  buffer?:number;
 }

--- a/projects/ngx-location-picker/src/lib/types/coordinate-query.model.ts
+++ b/projects/ngx-location-picker/src/lib/types/coordinate-query.model.ts
@@ -6,4 +6,5 @@ export interface CoordinateQueryModel {
   returnsingle?: boolean;
   totalresults?: number;
   cascadingRules: Array<CascadingCoordinateRulesModel>
+  buffer?: number;
 }

--- a/projects/ngx-location-picker/src/lib/types/delegate-search.model.ts
+++ b/projects/ngx-location-picker/src/lib/types/delegate-search.model.ts
@@ -18,4 +18,5 @@ export interface DelegateSearchModel {
   searchStreetNameForAddress: boolean;
   onlyAntwerp: boolean;
   countryCodes: string[];
+  bufferSearch?: number;
 }

--- a/projects/ngx-location-picker/src/lib/types/location-query.model.ts
+++ b/projects/ngx-location-picker/src/lib/types/location-query.model.ts
@@ -6,4 +6,5 @@ export interface LocationQueryModel {
   layers: Array<string>;
   onlyAntwerp: boolean;
   countries: Array<string>;
+  buffer?: number;
 }


### PR DESCRIPTION
Related to https://jira.antwerpen.be/browse/GIS-817, https://jira.antwerpen.be/browse/GIS-714 and https://jira.antwerpen.be/browse/GIS-797