### PR TITLE
Bugfix/angular18 two way binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [7.3.1]
+
+### Changed
+
+- With Angular 18 update in dependent projects, there is a breaking update surrounding expressions inside [(ngModel)].
+- Based on: https://github.com/angular/angular/tree/18.0.3/packages/core/schematics/migrations/invalid-two-way-bindings
+
 ## [7.3.0]
 
 ### Added

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.html
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.html
@@ -2,7 +2,7 @@
   <div class="a-input__search" [class.has-sidebar]="hasSidebar">
     <div class="a-input__wrapper has-inline-addon">
       <input #leafletSearch id="leaflet-search" type="text" name="leaflet-search" [placeholder]="placeholder"
-        [attr.aria-label]="textInputAriaLabel" [(ngModel)]="selectedLocation && selectedLocation.label"
+        [attr.aria-label]="textInputAriaLabel" [(ngModel)]="selectedLocationLabel"
         (ngModelChange)="onInputChange($event)" autocomplete="off" (blur)="didSearch = false" />
       <div class="inline-addon" *ngIf="showClearInputButton">
         <div *ngIf="searching" class="a-spinner" role="alert">

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
@@ -291,6 +291,16 @@ export class NgxLocationPickerComponent
     this.propagateChange(this._selectedLocation);
   }
 
+  get selectedLocationLabel(): string {
+    return this._selectedLocation?.label || '';
+  }
+
+  set selectedLocationLabel(value: string) {
+    if (this._selectedLocation) {
+      this._selectedLocation.label = value;
+    }
+  }
+
   /**
    * Checks if input field has a value
    */


### PR DESCRIPTION
With Angular 18 update in dependent projects, there is a breaking update surrounding expressions inside [(ngModel)].

Based on:
https://github.com/angular/angular/tree/18.0.3/packages/core/schematics/migrations/invalid-two-way-bindings