### PR TITLE
bugfix/EscapeMaliciousCharactersFromInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Prevent/escape malicious characters to be send thourgh input to the backend.
+- Prevent malicious characters to be send thourgh input to the backend.
 
 ## [7.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 "### Fixed" for any bug fixes.
 "### Security" in case of vulnerabilities.
 -->
+## [7.5.0]
+
+### Changed
+
+- Prevent/escape malicious characters to be send thourgh input to the backend.
+
 ## [7.4.0]
 
 ### Changed

--- a/projects/ngx-location-picker/src/lib/directives/highlight-search.directive.ts
+++ b/projects/ngx-location-picker/src/lib/directives/highlight-search.directive.ts
@@ -12,7 +12,7 @@ export class HighlightSearchDirective implements PipeTransform {
     }
 
     try {
-      // Espace malicious characters
+      // Remove malicious characters
       const maliciousCharacters = /[\*\%\;\|\<\>\\\/\{\}\[\]\n\r]/g;
       args = args.replace(maliciousCharacters, "");
 

--- a/projects/ngx-location-picker/src/lib/directives/highlight-search.directive.ts
+++ b/projects/ngx-location-picker/src/lib/directives/highlight-search.directive.ts
@@ -13,7 +13,7 @@ export class HighlightSearchDirective implements PipeTransform {
 
     try {
       // Remove malicious characters
-      const maliciousCharacters = /[\*\%\;\|\<\>\\\/\{\}\[\]\n\r]/g;
+      const maliciousCharacters = /[\*\%\;\|\<\>\\\/\{\}\[\]\n\r\.\--\?]/g;
       args = args.replace(maliciousCharacters, "");
 
       const regEx = new RegExp(args, 'ig');

--- a/projects/ngx-location-picker/src/lib/directives/highlight-search.directive.ts
+++ b/projects/ngx-location-picker/src/lib/directives/highlight-search.directive.ts
@@ -13,7 +13,7 @@ export class HighlightSearchDirective implements PipeTransform {
 
     try {
       // Remove malicious characters
-      const maliciousCharacters = /[\*\%\;\|\<\>\\\/\{\}\[\]\n\r\.\--\?]/g;
+      const maliciousCharacters = /[\*\%\;\|\<\>\{\}\[\]\/\\\n\r\?\.\--]/g;
       args = args.replace(maliciousCharacters, "");
 
       const regEx = new RegExp(args, 'ig');

--- a/projects/ngx-location-picker/src/lib/directives/highlight-search.directive.ts
+++ b/projects/ngx-location-picker/src/lib/directives/highlight-search.directive.ts
@@ -12,6 +12,10 @@ export class HighlightSearchDirective implements PipeTransform {
     }
 
     try {
+      // Espace malicious characters
+      const maliciousCharacters = /[\*\%\;\|\<\>\\\/\{\}\[\]\n\r]/g;
+      args = args.replace(maliciousCharacters, "");
+
       const regEx = new RegExp(args, 'ig');
       return value.replace(regEx, (match) => `<strong>${match}</strong>`);
     } catch (e) {

--- a/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
+++ b/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
@@ -81,7 +81,7 @@ export class NgxLocationPickerHelper {
   normalizeSearchValue(value: string) {
     if (!this.isCoordinate(value)) {
       // Remove malicious characters
-      const maliciousCharacters = /[\*\%\;\|\<\>\\\/\{\}\[\]\n\r]/g;
+      const maliciousCharacters = /[\*\%\;\|\<\>\\\/\{\}\[\]\n\r\.\--\?]/g;
       value = value.replace(maliciousCharacters, "");
 
       const hasBrackets = value.match(/\(.*?\)/);

--- a/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
+++ b/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
@@ -81,7 +81,7 @@ export class NgxLocationPickerHelper {
   normalizeSearchValue(value: string) {
     if (!this.isCoordinate(value)) {
       // Remove malicious characters
-      const maliciousCharacters = /[\*\%\;\|\<\>\\\/\{\}\[\]\n\r\.\--\?]/g;
+      const maliciousCharacters = /[\*\%\;\|\<\>\{\}\[\]\/\\\n\r\?\.\--]/g;
       value = value.replace(maliciousCharacters, "");
 
       const hasBrackets = value.match(/\(.*?\)/);

--- a/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
+++ b/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
@@ -80,7 +80,7 @@ export class NgxLocationPickerHelper {
    */
   normalizeSearchValue(value: string) {
     if (!this.isCoordinate(value)) {
-      // Espace malicious characters
+      // Remove malicious characters
       const maliciousCharacters = /[\*\%\;\|\<\>\\\/\{\}\[\]\n\r]/g;
       value = value.replace(maliciousCharacters, "");
 

--- a/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
+++ b/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
@@ -80,8 +80,11 @@ export class NgxLocationPickerHelper {
    */
   normalizeSearchValue(value: string) {
     if (!this.isCoordinate(value)) {
-      const hasBrackets = value.match(/\(.*?\)/);
+      // Espace malicious characters
+      const maliciousCharacters = /[\*\%\;\|\<\>\\\/\{\}\[\]\n\r]/g;
+      value = value.replace(maliciousCharacters, "");
 
+      const hasBrackets = value.match(/\(.*?\)/);
       if (hasBrackets && hasBrackets.length) return value.replace(` ${hasBrackets}`, "");
     }
     return value;


### PR DESCRIPTION
This PR is used to escape and prevent malicious characters to be send though the search field to the backend. This is a fix as a result of a pentest.

Characters that are being escaped: 
![image](https://github.com/user-attachments/assets/bf1cb200-b556-481b-94d4-28e217413ceb)


More information can be found on: https://jira.antwerpen.be/browse/GIS-881 