### PR TITLE
bugfix/SearchAddressOnStreetChoice

### DIFF
--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
@@ -589,6 +589,9 @@ export class NgxLocationPickerComponent
           (response: LocationModel[] | AddressModel[] | CoordinateModel[]) => {
             this.foundLocations = response;
 
+            // Reset location search fields when selected street name does not match the search value
+            if(this.previousLocation && 'formattedAddress' in this.previousLocation && !this.inputStringMatchesSelectedStreetName(searchValue as string, this.previousLocation?.street?.streetName)) this.resetLocationSearchFields();
+
             //adds used coordinate to result list
             if (this.addCoordinateToResultsAt && this.pickedLocation) {
               this.foundLocations.splice(
@@ -1205,5 +1208,12 @@ export class NgxLocationPickerComponent
    */
   private setNotification(notification: NotificationModel) {
     this.leafletNotification = notification;
+  }
+
+  /**
+   * Does input string match the selected street name
+   */
+  private inputStringMatchesSelectedStreetName(input: string, expectedStreetName: string): boolean {
+    return input?.trim()?.toLocaleLowerCase().startsWith(expectedStreetName?.trim()?.toLocaleLowerCase());
   }
 }

--- a/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
+++ b/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
@@ -80,8 +80,11 @@ export class NgxLocationPickerHelper {
    */
   normalizeSearchValue(value: string) {
     if (!this.isCoordinate(value)) {
-      const hasBrackets = value.match(/\(.*?\)/);
+      // Remove malicious characters
+      const maliciousCharacters = /[\*\%\;\|\<\>\{\}\[\]\/\\\n\r\?\.\--]/g;
+      value = value.replace(maliciousCharacters, "");
 
+      const hasBrackets = value.match(/\(.*?\)/);
       if (hasBrackets && hasBrackets.length) return value.replace(` ${hasBrackets}`, "");
     }
     return value;
@@ -188,11 +191,12 @@ export class NgxLocationPickerHelper {
     onlyAntwerp: boolean,
     countryCodes: string[],
     buffer?: number,
-    coordinateSearch?: LatLngModel
+    coordinateSearch?: LatLngModel,
+    streetIds?: number[],
   ): AddressQueryModel {
     const streetAndNumber: AddressQueryModel = {
       streetname: "",
-      streetids: [],
+      streetids: streetIds ?? [],
       housenumber: "",
       onlyAntwerp: onlyAntwerp,
       countries: countryCodes,

--- a/projects/ngx-location-picker/src/lib/services/ngx-location-picker.service.ts
+++ b/projects/ngx-location-picker/src/lib/services/ngx-location-picker.service.ts
@@ -67,7 +67,8 @@ export class NgxLocationPickerService {
         delegateSearch.onlyAntwerp,
         delegateSearch.countryCodes,
         delegateSearch.bufferSearch,
-        delegateSearch.coordinateSearch
+        delegateSearch.coordinateSearch,
+        delegateSearch?.selectedLocation && (delegateSearch?.selectedLocation as LocationModel)?.streetNameId ? [(delegateSearch?.selectedLocation as LocationModel)?.streetNameId] : delegateSearch.selectedLocation && (delegateSearch?.selectedLocation as AddressModel)?.street?.streetNameId ? [(delegateSearch?.selectedLocation as AddressModel)?.street?.streetNameId] : []
       );
       if (delegateSearch.searchStreetNameForAddress) {
         const locationQuery: LocationQueryModel = {
@@ -82,7 +83,6 @@ export class NgxLocationPickerService {
           xcoord: delegateSearch.coordinateSearch?.lat,
           ycoord: delegateSearch.coordinateSearch?.lng,
         };
-
         return this.searchLocations(locationQuery);
       } else {
         return this.searchAddresses(addressQuery);


### PR DESCRIPTION
When a particular street is selected, followed by a house number, consideration must be given to which street an address should be searched for. The street id is now passed to the address call. Until now this was not the case, resulting in the return of addresses unrelated to the selected street.

If an address is selected, this address will be made active until the input string no longer matches the street name of the active address. When this is the case, the location search fields are reset.