### PR TITLE
Bugfix/search address and actual location marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.
 "### Security" in case of vulnerabilities.
 -->
 
+## [7.6.0]
+
+### Changed
+
+- When searching for an address, do not send streetname in the query if combination streetnameid and housenumber is available for addresses in Antwerp.
+- Change actual location marker color.
+
 ## [7.5.0]
 
 ### Changed

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
@@ -639,13 +639,13 @@ export class NgxLocationPickerComponent
           selectedLocation.address.addressPosition.wgs84.lat,
           selectedLocation.address.addressPosition.wgs84.lng,
         ];
-        this.addResultMarker(coords, { color: "var(--THEME1-600)", opacity: "40" });
+        this.addResultMarker(coords, { color: "var(--THEME1-600)", opacity: "40", strokeColor: "var(--THEME1-600)", strokeWidth: "2px"});
       } else if (selectedLocation.addressPosition && selectedLocation.addressPosition.wgs84) {
         const coords: Array<number> = [
           selectedLocation.addressPosition.wgs84.lat,
           selectedLocation.addressPosition.wgs84.lng,
         ];
-        this.addResultMarker(coords);
+        this.addResultMarker(coords, { color: "var(--THEME1-600)", opacity: "40", strokeColor: "var(--THEME1-600)", strokeWidth: "2px"});
       } else if (selectedLocation.position) {
         if (selectedLocation.position.wgs84) {
           const coords: Array<number> = [
@@ -996,7 +996,7 @@ export class NgxLocationPickerComponent
   }
 
   /* Adds a marker on a given coordinate and zooms in on this location. */
-  private addResultMarker(coords: number[], pointDetails?: {color: string, opacity: string}): void {
+  private addResultMarker(coords: number[], pointDetails?: {color: string, opacity: string, strokeColor: string, strokeWidth: string}): void {
     this.removeGeometry();
     this.calculatedLocationMarker = this.leafletMap.addHtmlMarker(
       coords,
@@ -1069,10 +1069,10 @@ export class NgxLocationPickerComponent
       top: "-0.75rem",
       left: "-0.6rem",
     },
-    pointDetails?: {color: string; opacity: string}
+    pointDetails?: {color: string; opacity: string, strokeColor: string, strokeWidth: string}
   ) {
     const markerStyle = `color: ${color}; font-size: ${size}; top: ${position.top}; left: ${position.left}`;
-    const markerIcon = `<svg aria-hidden="true"><use href="#${icon}" style="fill: ${pointDetails?.color}; opacity: ${pointDetails?.opacity}%;" /></svg>`;
+    const markerIcon = `<svg aria-hidden="true"><use href="#${icon}" style="fill: ${pointDetails?.color}; fill-opacity: ${pointDetails?.opacity}%; stroke: ${pointDetails?.strokeColor}; stroke-width: ${pointDetails?.strokeWidth}; stroke-opacity: 1;" /></svg>`;
 
     return `<span style="${markerStyle}" class="ai ngx-location-picker-marker">${markerIcon}</span>`;
   }

--- a/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
+++ b/projects/ngx-location-picker/src/lib/services/ngx-location-picker.helper.ts
@@ -205,24 +205,25 @@ export class NgxLocationPickerHelper {
       ycoord: coordinateSearch?.lng
     };
 
+    
     const addressParts: Array<string> =
-      query && query.trim().length > 0 ? query.split(" ") : null;
-
+    query && query.trim().length > 0 ? query.split(" ") : null;
+    
     if (addressParts) {
       addressParts.map((part, index) => {
         const matches = /[0-9]\w?$/.exec(part);
-
+        
         if (index > 0 && matches) {
           if (!!streetAndNumber.housenumber || matches.index === 0) {
             streetAndNumber.housenumber += part + "";
             return;
           }
         }
-
+        
         if (streetAndNumber.streetname) {
           streetAndNumber.streetname += " ";
         }
-
+        
         if (/\d$/.test(part) && index + 1 === addressParts.length) {
           streetAndNumber.housenumber = part.replace(/^[0-9]\-[a-z]+/g, "");
           streetAndNumber.streetname += part.replace(/\d*$/, "");
@@ -232,7 +233,7 @@ export class NgxLocationPickerHelper {
           streetAndNumber.streetname += part;
         }
       });
-
+      
       streetAndNumber.streetname = streetAndNumber.streetname
         .trim()
         .replace(/\s+\([a-z\s\,]+\)$/gi, "");
@@ -250,6 +251,11 @@ export class NgxLocationPickerHelper {
       streetAndNumber.housenumber = streetAndNumber.housenumber
         .trim()
         .replace(/^\([a-z\s\,]*\)/gi, "");
+
+      // The user first chooses a street and can then add a house number. The address is looked up based on the streetnameid and house number.
+      // The combination of a street name id and a house number are unique to Antwerp.
+      // Including a street name has no added value if the housenumer and streetnameid are known
+      if(streetAndNumber.onlyAntwerp && streetAndNumber.streetids.length !== 0 && streetAndNumber.housenumber) streetAndNumber.streetname = null;
     }
 
     // if previous selected location is of type LocationModel and location has streetid
@@ -263,7 +269,7 @@ export class NgxLocationPickerHelper {
         selectedLocation.streetName.toUpperCase() ===
         streetAndNumber.streetname.toUpperCase()
       ) {
-        streetAndNumber.streetname = "";
+        streetAndNumber.streetname = null;
         streetAndNumber.streetids.push(selectedLocation.streetNameId);
       }
     }


### PR DESCRIPTION
This PR group two fixes:

- Passing the streetname to the backend has no added value if the combination of streetnameid and housnumber is known.

The user first chooses a street and can then add a house number. The address is looked up based on the streetnameid and house number. The combination of a street name id and a house number are unique to Antwerp. Including a street name has no added value if the housenumer and streetnameid are known

- Changed actual location marker color following the Antwerp UI standards