### PR TITLE
Fix: Added additional check for previousLocation reset, it should not be applicable to search values that are coordinates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fix: Added additional check for previousLocation reset, it should not be applicable to search values that are coordinates.
+- Added additional check for previousLocation reset, it should not be applicable to search values that are coordinates.
 
 ## [7.7.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Added additional check for previousLocation reset, it should not be applicable to search values that are coordinates.
+- Added additional check for locations with shape, they should not be Points to be added as geometry. Also added support for Position_wgs84_lat and Position_wgs84_lng, these coordinates are much preciser for locations.
 
 ## [7.7.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 -->
 ## Unreleased
 
+### Fixed
+
+- Fix: Added additional check for previousLocation reset, it should not be applicable to search values that are coordinates.
+
 ## [7.7.4]
 
 ### Changed

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
@@ -566,8 +566,8 @@ export class NgxLocationPickerComponent
       searchValue = this.locationPickerHelper.normalizeSearchValue(searchValue);
 
       // Reset the previous location if the current search value does not equal the previous one, only applicable to addresses and locations.
-      if((this.previousLocation && 'formattedAddress' in this.previousLocation && !this.inputStringEqualsSelectedStreetName(searchValue as string, this.previousLocation?.street?.streetName))
-        || (this.previousLocation && 'position' in this.previousLocation && !this.inputStringEqualsSelectedStreetName(searchValue as string, this.previousLocation?.name)))
+      if(((this.previousLocation && 'formattedAddress' in this.previousLocation && !this.inputStringEqualsSelectedStreetName(searchValue as string, this.previousLocation?.street?.streetName))
+        || (this.previousLocation && 'position' in this.previousLocation && !this.inputStringEqualsSelectedStreetName(searchValue as string, this.previousLocation?.name))) &&  !this.locationPickerHelper.isCoordinate(searchValue))
           this.previousLocation = null;
 
       const delegateSearch: DelegateSearchModel = {

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
@@ -665,17 +665,26 @@ export class NgxLocationPickerComponent
         selectedLocation.location.position &&
         (selectedLocation.location.position.geometry || selectedLocation.location.position.wgs84)
       ) {
-        if (selectedLocation.label && selectedLocation.location.position.geometry && selectedLocation.location.position.geometryShape) {
+        if (selectedLocation.label && selectedLocation.location.position.geometry && selectedLocation.location.position.geometryShape && selectedLocation.location.position.geometryShape !== "Point") {
           this.addMapGeoJson(
             selectedLocation.label,
             selectedLocation.location.position.geometryShape,
             selectedLocation.location.position.geometry
           );
         } else {
-          const coords: Array<number> = [
-            selectedLocation.location.position.wgs84.lat,
-            selectedLocation.location.position.wgs84.lng,
-          ];
+          let coords: Array<number>;
+          if (selectedLocation.layerAttributes?.Position_wgs84_lat !== undefined &&
+            selectedLocation.layerAttributes?.Position_wgs84_lon !== undefined) {
+            coords = [
+              selectedLocation.layerAttributes.Position_wgs84_lat,
+              selectedLocation.layerAttributes.Position_wgs84_lon,
+            ];
+          } else {
+            coords = [
+              selectedLocation.location.position.wgs84.lat,
+              selectedLocation.location.position.wgs84.lng,
+            ];
+          }
           this.addResultMarker(coords, { color: "var(--THEME1-600)", opacity: "40", strokeColor: "var(--THEME1-600)", strokeWidth: "2px"});
         }
       } else {


### PR DESCRIPTION
https://jira.antwerpen.be/browse/GIS-890 