### PR TITLE
Changed: Adjusted location picking icon dragging center, the dragging point is now the bottom of the icon instead of the center.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to this project will be documented in this file.
 -->
 ## Unreleased
 
+### Changed
+
+- Adjusted location picking icon dragging center, the dragging point is now the bottom of the icon instead of the center.
+
+
 ## [7.8.0]
 
 ### Added

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.scss
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.scss
@@ -17,7 +17,7 @@
   .is-picking {
     .leaflet-grab,
     .leaflet-interactive {
-      cursor: url('data:image/svg+xml;utf8,<svg viewBox=%220 0 24 24%22 xmlns=%22http://www.w3.org/2000/svg%22><g stroke-linecap=%22round%22 stroke-width=%226.25%%22 stroke=%22%230057b7%22 fill=%22none%22 stroke-linejoin=%22round%22><path d="M12 .71l-.01 0c4.14-.01 7.5 3.35 7.5 7.49 0 3.54-5.5 12.38-7.08 14.85l-.001 0c-.15.23-.46.3-.7.15 -.07-.04-.12-.1-.16-.16 -1.58-2.47-7.08-11.31-7.08-14.85l0-.01c0-4.15 3.35-7.5 7.5-7.5Z"/><path d="M12 5.21a3 3 0 1 0 0 6 3 3 0 1 0 0-6Z%22/></g></svg>') 12 12, pointer;
+      cursor: url('data:image/svg+xml;utf8,<svg viewBox=%220 0 24 24%22 xmlns=%22http://www.w3.org/2000/svg%22><g stroke-linecap=%22round%22 stroke-width=%226.25%%22 stroke=%22%230057b7%22 fill=%22none%22 stroke-linejoin=%22round%22><path d="M12 .71l-.01 0c4.14-.01 7.5 3.35 7.5 7.49 0 3.54-5.5 12.38-7.08 14.85l-.001 0c-.15.23-.46.3-.7.15 -.07-.04-.12-.1-.16-.16 -1.58-2.47-7.08-11.31-7.08-14.85l0-.01c0-4.15 3.35-7.5 7.5-7.5Z"/><path d="M12 5.21a3 3 0 1 0 0 6 3 3 0 1 0 0-6Z%22/></g></svg>') 16 24, pointer;
     }
   }
 


### PR DESCRIPTION
RELATED JIRA TICKET: https://jira.antwerpen.be/browse/GIS-907 