### PR TITLE
Feature: Added support of postcode and place/municipality search for addresses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file.
 
 - Added support of postcode and place/municipality search for addresses.
 
+### Fixed
+
+- Changed click event listeners to pointerdown event listeners for touchpad support.
+
 ## [7.8.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 -->
 ## Unreleased
 
+### Added
+
+- Added support of postcode and place/municipality search for addresses.
+
 ## [7.8.1]
 
 ### Fixed

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.html
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.html
@@ -11,7 +11,7 @@
           </span>
         </div>
         <button *ngIf="!inputHasValue && !searching" class="a-button a-button--s a-button--text has-icon" type="button"
-          (click)="emptyField()" [attr.aria-label]="clearInputAriaLabel">
+          (pointerdown)="emptyField()" [attr.aria-label]="clearInputAriaLabel">
           <aui-icon name="ai-close"></aui-icon>
         </button>
       </div>
@@ -26,14 +26,14 @@
               <a href="#" [class]="{
                 'a-list__content': true,
                 'is-active': ii === highlightedLocationResult,
-              }" (click)="onLocationSelect($event, location)">
+              }" (pointerdown)="onLocationSelect($event, location)">
                 <p [innerHTML]="location.label | highlight: selectedLocation?.label"></p>
                 <small>{{ location.layer }}</small>
               </a>
             </li>
           </ul>
         </ng-template>
-        <div *ngIf="!hasResults && pickedLocation && !searching" (click)="onLocationSelect($event, selectedLocation)"
+        <div *ngIf="!hasResults && pickedLocation && !searching" (pointerdown)="onLocationSelect($event, selectedLocation)"
           class="use-coordinate" [class.is-highlighted]="!hasResults && pickedLocation">
           <p>{{ defaultOptionLabel }}</p>
           <small>{{ selectedLocation.label }}</small>
@@ -46,7 +46,7 @@
         <p><aui-icon [name]="leafletNotification.icon" class="u-margin-right-xxs"></aui-icon> {{
           leafletNotification.text }}</p>
         <button class="a-button a-button--text a-button--{{ leafletNotification.status }} has-icon m-alert__close"
-          aria-label="Close" (click)="closeNotification()">
+          aria-label="Close" (pointerdown)="closeNotification()">
           <aui-icon name="ai-close"></aui-icon>
         </button>
       </div>
@@ -71,14 +71,14 @@
   (filteredResult)="onResultFiltered($event)">
     <div controls bottom left>
       <button type="button" class="a-button has-icon u-margin-bottom-xs button-location-picking"
-        (click)="pickLocationOnMap()" [class.a-button--outlined]="pickLocationActive"
+        (pointerdown)="pickLocationOnMap()" [class.a-button--outlined]="pickLocationActive"
         [attr.aria-label]="locationPickAriaLabel">
         <aui-icon name="ai-pin"></aui-icon>
       </button>
     </div>
     <div controls bottom right>
       <button type="button" class="a-button has-icon" [attr.aria-label]="locateMeAriaLabel"
-        (click)="getDeviceLocation()">
+        (pointerdown)="getDeviceLocation()">
         <aui-icon name="ai-compass-arrow"></aui-icon>
       </button>
     </div>

--- a/projects/ngx-location-picker/src/lib/types/address-query.model.ts
+++ b/projects/ngx-location-picker/src/lib/types/address-query.model.ts
@@ -2,6 +2,8 @@ export interface AddressQueryModel {
   streetname: string;
   streetids: number[];
   housenumber: string;
+  postcode: string;
+  place: string;
   onlyAntwerp: boolean;
   countries: string[];
   buffer?: number;


### PR DESCRIPTION
https://jira.antwerpen.be/browse/GIS-923

All of the following use cases should be handled as addresses and the parameters should be set right:

- Lange Dijkstraat 15
  - street: Lange Dijkstraat 
  - housenumber: 15
- Lange Dijkstraat 15ba
  - street: Lange Dijkstraat 
  - housenumber: 15ba
- Lange Dijkstraat 15,
  - street: Lange Dijkstraat 
  - housenumber: 15
- Lange Dijkstraat 15, 2
  - street: Lange Dijkstraat 
  - housenumber: 15
  - postcode: 2  <--- will be handled as STARTS WITH in the backend
- Lange Dijkstraat 15, 20
  - street: Lange Dijkstraat 
  - housenumber: 15
  - postcode: 20  <--- will be handled as STARTS WITH in the backend
- Lange Dijkstraat 15, 206
  - street: Lange Dijkstraat 
  - housenumber: 15
  - postcode: 206  <--- will be handled as STARTS WITH in the backend
- Lange Dijkstraat 15, 2060
  - street: Lange Dijkstraat 
  - housenumber: 15
  - postcode: 2060
- Lange Dijkstraat 15, Antwerpen
  - street: Lange Dijkstraat 
  - housenumber: 15
  - place: Antwerpen 
- Lange Dijkstraat 15, 2060 Antwerpen
  - street: Lange Dijkstraat 
  - housenumber: 15
  - postcode: 2060
  - place: Antwerpen 