### PR TITLE
Feature: Added spinner for "get location" feature for GIS-930 & Fix: Altered default trackingTimeout and preferredAccuracy to a lower value for an acceptable time for Edge users for retrieving locations for GIS-930.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Added spinner for "get location" feature.
+
+### Changed
+
+- Altered default trackingTimeout and preferredAccuracy to a lower value for an acceptable time for Edge users for retrieving locations.
+
 ## [7.8.8]
 
 ### Fixed

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.html
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.html
@@ -77,10 +77,16 @@
       </button>
     </div>
     <div controls bottom right>
-      <button type="button" class="a-button has-icon" [attr.aria-label]="locateMeAriaLabel"
-        (click)="getDeviceLocation()">
-        <aui-icon name="ai-compass-arrow"></aui-icon>
-      </button>
+        <button type="button" class="a-button has-icon" [attr.aria-label]="locateMeAriaLabel"
+                [class.a-button--outlined]="isLocating"
+                (click)="getDeviceLocation()">
+            <aui-icon *ngIf="!isLocating" name="ai-compass-arrow"></aui-icon>
+            <div *ngIf="isLocating" class="a-spinner" role="alert">
+              <span class="a-spinner__circle">
+                <span class="u-screen-reader-only">Fetching data...</span>
+              </span>
+            </div>
+        </button>
     </div>
     <div *ngIf="hasSidebar">
       <ng-content></ng-content>

--- a/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
+++ b/projects/ngx-location-picker/src/lib/components/ngx-location-picker.component.ts
@@ -187,8 +187,8 @@ export class NgxLocationPickerComponent
     enableHighAccuracy: false,
     timeout: Infinity,
     maximumAge: 0,
-    preferredAccuracy: 50,
-    trackingTimeout: 5000,
+    preferredAccuracy: 25,
+    trackingTimeout: 2000,
   };
   /* If true, will use watchposition to track current position */
   @Input() trackPosition: boolean = false;


### PR DESCRIPTION
Feature: Added spinner for "get location" feature for GIS-930.
Fix: Altered default trackingTimeout and preferredAccuracy to a lower value for an acceptable time for Edge users for retrieving locations for GIS-930.

https://jira.antwerpen.be/browse/GIS-930 